### PR TITLE
fixing GetFloatVector

### DIFF
--- a/src/Utility/SimpleConfig.cpp
+++ b/src/Utility/SimpleConfig.cpp
@@ -228,7 +228,7 @@ bool SimpleConfig::GetFloatVector(const string& param, vector<float>& ret)
   string s = i->second;
   vector<string> spl = SLR::Split(s, ',');
   ret.clear();
-  for (unsigned i = 0; i < s.size(); i++)
+  for (unsigned i = 0; i < spl.size(); i++)
   {
     try
     {


### PR DESCRIPTION
The length of string is used instead of the length of vector.